### PR TITLE
Fix: Feedback addressed by allowing spaces in function inputs

### DIFF
--- a/src/worldfinder/get_country_statistic.py
+++ b/src/worldfinder/get_country_statistic.py
@@ -64,7 +64,7 @@ def get_country_statistic(country, statistic):
     stat_list = ["population", "gdp", "birth rate", "cpi", "unemployment rate"]
 
     # Check that statistic is a correct option
-    if statistic.lower() not in stat_list:
+    if statistic.lower().strip() not in stat_list:
         raise ValueError(
             'statistic must be population, gdp, birth rate, cpi, or '
             'unemployment rate'
@@ -74,7 +74,7 @@ def get_country_statistic(country, statistic):
     country_df = load_data("data", "countries.csv")
 
     single_country_df = country_df[
-        country_df["Country"].str.lower() == country.lower()
+        country_df["Country"].str.lower() == country.lower().strip()
     ]
 
     # Check that country exists in dataframe
@@ -86,6 +86,6 @@ def get_country_statistic(country, statistic):
     # Convert column names to lowercase
     single_country_df.columns = single_country_df.columns.str.lower()
 
-    stat = single_country_df.iloc[0][statistic.lower()]
+    stat = single_country_df.iloc[0][statistic.lower().strip()]
 
     return stat

--- a/tests/test_get_country_statistic.py
+++ b/tests/test_get_country_statistic.py
@@ -80,3 +80,11 @@ def test_get_country_statistic_valid_country():
     invalid_country = "cnada"
     with pytest.raises(ValueError, match=f"country '{invalid_country}' is not a valid country name."):
         get_country_statistic(invalid_country, "population")
+
+
+def test_get_country_with_spaces_input():
+    """
+    Test that the function returns when the country is passed with trailing/leading spaces 
+    """
+    result = get_country_statistic("   Canada    ", "population")
+    assert result == '36,991,981'


### PR DESCRIPTION
Allow spaces in function inputs for get_country_statistic

Addresses this issue: https://github.com/UBC-MDS/DSCI524-2425-17-worldfinder/issues/72